### PR TITLE
polish: rename stop-btn, fix disclaimer colors, benchmark track, remove !important

### DIFF
--- a/popup/popup.css
+++ b/popup/popup.css
@@ -162,8 +162,6 @@ body {
 /* Main content */
 .main {
   padding: 0 20px 20px;
-  max-width: 1200px;
-  margin: 0 auto;
 }
 
 /* Section titles */
@@ -1460,7 +1458,7 @@ body {
     width: 100%;
 }
 
-.primary-btn, .secondary-btn {
+.primary-btn, .secondary-btn, .stop-btn {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1492,24 +1490,24 @@ body {
     box-shadow: 0 1px 2px rgba(79, 70, 229, 0.2);
 }
 
-.secondary-btn {
+.stop-btn {
     background: #ef4444;
     color: white;
     box-shadow: 0 2px 4px rgba(239, 68, 68, 0.2);
 }
 
-.secondary-btn:hover {
+.stop-btn:hover {
     background: #dc2626;
     transform: translateY(-1px);
     box-shadow: 0 4px 6px rgba(239, 68, 68, 0.3);
 }
 
-.secondary-btn:active {
+.stop-btn:active {
     transform: translateY(0);
     box-shadow: 0 1px 2px rgba(239, 68, 68, 0.2);
 }
 
-.primary-btn:disabled, .secondary-btn:disabled {
+.primary-btn:disabled, .stop-btn:disabled {
     background: #d1d5db;
     cursor: not-allowed;
     transform: none;
@@ -1652,9 +1650,9 @@ body {
   transition: color 0.2s ease, background-color 0.2s ease;
 }
 
-.clear-search-btn:hover {
-  color: #e5e7eb !important;
-  background: rgba(255, 255, 255, 0.1) !important;
+.search-filter-row .clear-search-btn:hover {
+  color: var(--console-text);
+  background: oklch(100% 0 0 / 0.1);
   border-radius: 50%;
 }
 
@@ -1697,11 +1695,11 @@ body {
   color: var(--console-text);
 }
 
-/* Secondary button for search empty state */
+/* Secondary button — neutral ghost variant for search empty state */
 .secondary-btn {
-  background: rgba(255, 255, 255, 0.1);
-  color: #d1d5db;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: oklch(100% 0 0 / 0.08);
+  color: var(--console-muted);
+  border: 1px solid oklch(100% 0 0 / 0.18);
   border-radius: 6px;
   font-weight: 500;
   cursor: pointer;
@@ -1709,9 +1707,9 @@ body {
 }
 
 .secondary-btn:hover {
-  background: rgba(255, 255, 255, 0.2);
-  color: #ffffff;
-  border-color: rgba(255, 255, 255, 0.3);
+  background: oklch(100% 0 0 / 0.14);
+  color: var(--console-text);
+  border-color: oklch(100% 0 0 / 0.28);
 }
 
 .secondary-btn:active {
@@ -2153,7 +2151,7 @@ body {
 .benchmark-progress {
     width: 100%;
     height: 4px;
-    background-color: #e5e7eb;
+    background: oklch(100% 0 0 / 0.1);
     border-radius: 2px;
     margin: 16px 0;
     overflow: hidden;
@@ -2220,17 +2218,17 @@ body {
 }
 
 .speed-high {
-    color: #10b981 !important;
+    color: var(--console-success);
     font-weight: bold;
 }
 
 .speed-medium {
-    color: #f59e0b !important;
+    color: var(--console-warning);
     font-weight: bold;
 }
 
 .speed-low {
-    color: #ef4444 !important;
+    color: var(--console-danger);
     font-weight: bold;
 }
 
@@ -2578,9 +2576,9 @@ body {
 }
 
 .disclaimer-btn {
-  background: #3b82f6;
-  color: white;
-  border: none;
+  background: var(--console-accent);
+  color: var(--console-text);
+  border: 1px solid oklch(78% 0.12 276 / 0.45);
   border-radius: 8px;
   padding: 12px 24px;
   font-size: 16px;
@@ -2591,9 +2589,9 @@ body {
 }
 
 .disclaimer-btn:hover {
-  background: #2563eb;
+  background: oklch(69% 0.19 276);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.4);
+  box-shadow: 0 4px 12px oklch(22% 0.12 276 / 0.4);
 }
 
 .disclaimer-btn:active {
@@ -2601,17 +2599,18 @@ body {
 }
 
 .disclaimer-btn.primary {
-  background: #3b82f6;
+  background: var(--console-accent);
 }
 
 .disclaimer-btn.secondary {
-  background: #6b7280;
-  color: white;
+  background: oklch(38% 0.025 265);
+  color: var(--console-text);
+  border-color: var(--console-border);
 }
 
 .disclaimer-btn.secondary:hover {
-  background: #4b5563;
-  box-shadow: 0 4px 12px rgba(107, 114, 128, 0.4);
+  background: oklch(44% 0.03 265);
+  box-shadow: 0 4px 12px oklch(8% 0.02 265 / 0.4);
 }
 
 /* Disable interaction when disclaimer is showing */
@@ -2861,6 +2860,7 @@ body {
 }
 
 .secondary-btn,
+.stop-btn,
 .clear-btn,
 .danger-btn {
   border-radius: 10px;

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -104,7 +104,7 @@
             <button id="scanBtn" class="primary-btn" type="button">
                 <span class="scan-text">Scan Selected Platforms</span>
             </button>
-            <button id="stopBtn" class="secondary-btn" style="display: none;">
+            <button id="stopBtn" class="stop-btn" type="button" style="display: none;">
                 <span class="stop-text">Pause Scan</span>
             </button>
         </div>


### PR DESCRIPTION
## Summary
- Resolve duplicate `.secondary-btn` semantics by introducing `.stop-btn`
- Align disclaimer button palette with design tokens
- Fix benchmark progress track for dark mode
- Remove `!important` overrides and inert popup max-width

## Deferred
- Confidence details animation and dead-code cleanup in next PR
